### PR TITLE
Add ESLint and Prettier configuration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,20 @@
+module.exports = {
+    root: true,
+    parser: '@typescript-eslint/parser',
+    parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: __dirname,
+        sourceType: 'module',
+    },
+    plugins: ['@typescript-eslint'],
+    extends: [
+        'eslint:recommended',
+        'plugin:@typescript-eslint/recommended',
+        'prettier',
+    ],
+    env: {
+        browser: true,
+        es2020: true,
+        node: true,
+    },
+};

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+    "semi": true,
+    "singleQuote": true,
+    "tabWidth": 4,
+    "trailingComma": "es5"
+}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ npm run build
 La optimización de imágenes se realiza con el plugin `vite-imagetools`, que
 procesa los archivos durante la fase de build.
 
+El repositorio incluye configuración de **ESLint** y **Prettier** para mantener
+un estilo de código consistente. Puedes ejecutarlos manualmente con los
+scripts `npm run lint` y `npm run format`.
+
 ## Scripts Disponibles
 
 - `npm run dev` &ndash; Arranca Vite en modo desarrollo con recarga en caliente.
@@ -41,6 +45,8 @@ procesa los archivos durante la fase de build.
 - `npm run preview` &ndash; Sirve la build de producción de forma local.
 - `npm run compile` &ndash; Compila los archivos TypeScript a JavaScript.
 - `npm test` &ndash; Compila el proyecto y ejecuta la suite de pruebas.
+- `npm run lint` &ndash; Ejecuta ESLint sobre los archivos de `src/` y `tests/`.
+- `npm run format` &ndash; Aplica Prettier a todo el repositorio.
 
 ## Estructura del Repositorio
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "vite build",
     "compile": "tsc",
     "test": "npm run compile && node --test",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "eslint \"{src,tests}/**/*.{ts,js}\"",
+    "format": "prettier --write \"**/*.{ts,js,json,md}\""
   },
   "dependencies": {
     "phaser": "^3.90.0"
@@ -15,6 +17,11 @@
   "devDependencies": {
     "typescript": "^5.8.3",
     "vite": "^6.0.0",
-    "vite-imagetools": "^7.1.0"
+    "vite-imagetools": "^7.1.0",
+    "eslint": "^8.57.0",
+    "prettier": "^3.2.5",
+    "@typescript-eslint/parser": "^7.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "eslint-config-prettier": "^9.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- set up ESLint with TypeScript support
- add Prettier configuration for consistent formatting
- expose `npm run lint` and `npm run format` scripts
- document the new tooling in the README

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_684cd19bc7f483308950fab97cb8f6e7