### PR TITLE
Add themed graphics and improved UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Eureka Slot
 
-Eureka Slot es un esqueleto base para una máquina tragamonedas 5x3 desarrollada
-con Phaser 3 y empaquetada con Vite.
+Eureka Slot es un esqueleto base para una máquina tragamonedas 5x3 desarrollada con Phaser 3 y empaquetada con Vite. Incluye un set de símbolos SVG con temática de **Frutas Clásicas** y un marco dorado básico para ilustrar la personalización visual.
 
 ## Arquitectura del Juego
 
@@ -11,6 +10,7 @@ con Phaser 3 y empaquetada con Vite.
 - **GameManager** controla el saldo, los carretes y evalúa las combinaciones.
 - **Reel** y **Symbol** representan los carretes y sus símbolos.
 - Los utilitarios en `utils/` generan las tiradas y calculan los premios.
+- La interfaz incluye botones de **Girar** y **Apuesta Max** junto a indicadores de saldo, apuesta y premio.
 
 ## Configuración del Entorno de Desarrollo
 

--- a/src/GameManager.ts
+++ b/src/GameManager.ts
@@ -30,6 +30,7 @@ export default class GameManager {
         this.ui = new BalanceDisplay(scene, 10, 10);
         this.createReels();
         this.ui.setBalance(this.balance);
+        this.ui.setBet(this.betPerLine);
     }
 
     private createReels(): void {
@@ -56,5 +57,10 @@ export default class GameManager {
             this.ui.setWin(win);
             this.ui.setBalance(this.balance);
         });
+    }
+
+    setBetPerLine(value: number): void {
+        this.betPerLine = value;
+        this.ui.setBet(this.betPerLine);
     }
 }

--- a/src/components/BalanceDisplay.ts
+++ b/src/components/BalanceDisplay.ts
@@ -4,11 +4,13 @@ export default class BalanceDisplay {
     private scene: Phaser.Scene;
     private balanceText: Phaser.GameObjects.Text;
     private winText: Phaser.GameObjects.Text;
+    private betText: Phaser.GameObjects.Text;
 
     constructor(scene: Phaser.Scene, x: number, y: number) {
         this.scene = scene;
-        this.balanceText = scene.add.text(x, y, '', { font: '20px Arial', color: '#fff' });
-        this.winText = scene.add.text(x, y + 30, '', { font: '20px Arial', color: '#fff' });
+        this.balanceText = scene.add.text(x, y, '', { font: '26px Arial', color: '#fff' });
+        this.winText = scene.add.text(x, y + 40, '', { font: '26px Arial', color: '#fff' });
+        this.betText = scene.add.text(x, y + 80, '', { font: '26px Arial', color: '#fff' });
     }
 
     setBalance(balance: number): void {
@@ -17,5 +19,9 @@ export default class BalanceDisplay {
 
     setWin(win: number): void {
         this.winText.setText('Win: ' + win);
+    }
+
+    setBet(bet: number): void {
+        this.betText.setText('Bet: ' + bet);
     }
 }

--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -1,9 +1,8 @@
 import Phaser from 'phaser';
 
-interface PlaceholderSymbol {
+interface SymbolAsset {
     key: string;
-    color: number;
-    label: string;
+    svg: string;
 }
 
 export default class BootScene extends Phaser.Scene {
@@ -17,19 +16,66 @@ export default class BootScene extends Phaser.Scene {
     preload(): void {
         this.createLoadingGraphics();
 
-        const symbols: PlaceholderSymbol[] = [
-            { key: 'CHERRY', color: 0xff0000, label: 'C' },
-            { key: 'LEMON', color: 0xffff00, label: 'L' },
-            { key: 'ORANGE', color: 0xffa500, label: 'O' },
-            { key: 'GRAPE', color: 0x800080, label: 'G' },
-            { key: 'WATERMELON', color: 0x00ff00, label: 'W' },
-            { key: 'BELL', color: 0xffd700, label: 'B' },
-            { key: 'STAR', color: 0xffffff, label: '*' },
-            { key: 'SEVEN', color: 0xff0000, label: '7' }
+        const symbols: SymbolAsset[] = [
+            {
+                key: 'CHERRY',
+                svg: `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <circle cx="40" cy="60" r="15" fill="#ff4d4d" />
+  <circle cx="60" cy="60" r="15" fill="#ff4d4d" />
+  <path d="M50 45 v-20" stroke="#008000" stroke-width="4" />
+  <path d="M50 25 C45 15,55 15,50 25" stroke="#008000" stroke-width="4" fill="none" />
+</svg>`
+            },
+            {
+                key: 'LEMON',
+                svg: `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <ellipse cx="50" cy="50" rx="25" ry="15" fill="#fff44f" />
+</svg>`
+            },
+            {
+                key: 'ORANGE',
+                svg: `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <circle cx="50" cy="50" r="20" fill="#ffa500" />
+</svg>`
+            },
+            {
+                key: 'GRAPE',
+                svg: `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <circle cx="50" cy="40" r="10" fill="#8a2be2" />
+  <circle cx="40" cy="50" r="10" fill="#8a2be2" />
+  <circle cx="60" cy="50" r="10" fill="#8a2be2" />
+  <circle cx="50" cy="60" r="10" fill="#8a2be2" />
+</svg>`
+            },
+            {
+                key: 'WATERMELON',
+                svg: `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <ellipse cx="50" cy="55" rx="25" ry="15" fill="#00a859" />
+  <ellipse cx="50" cy="55" rx="20" ry="10" fill="#ff3366" />
+</svg>`
+            },
+            {
+                key: 'BELL',
+                svg: `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <path d="M50 30 C70 30,70 60,50 60 C30 60,30 30,50 30 Z" fill="#ffd700" />
+  <rect x="45" y="60" width="10" height="10" fill="#ffd700" />
+</svg>`
+            },
+            {
+                key: 'STAR',
+                svg: `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <polygon points="50,15 61,40 88,40 66,58 74,85 50,70 26,85 34,58 12,40 39,40"  fill="#fff14f" />
+</svg>`
+            },
+            {
+                key: 'SEVEN',
+                svg: `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <text x="50" y="70" font-family="Arial" font-size="70" text-anchor="middle" fill="#ff0000">7</text>
+</svg>`
+            }
         ];
 
-        symbols.forEach(({ key, color, label }): void => {
-            const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width='100' height='100' fill='#${color.toString(16).padStart(6, '0')}'/><text x='50' y='70' font-family='Arial' font-size='64' text-anchor='middle' fill='#000'>${label}</text></svg>`;
+        symbols.forEach(({ key, svg }): void => {
             const url = 'data:image/svg+xml,' + encodeURIComponent(svg);
             this.load.image(key, url);
         });

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -11,11 +11,25 @@ export default class GameScene extends Phaser.Scene {
 
     create(): void {
         this.manager = new GameManager(this, config);
+        this.add.rectangle(400, 300, 800, 600, 0x1a1a2d);
+        const frame = this.add.graphics();
+        frame.lineStyle(8, 0xffd700);
+        frame.strokeRect(80, 40, 640, 520);
 
-        const spinBtn = this.add.rectangle(700, 500, 80, 40, 0x00ff00).setInteractive();
-        this.add.text(700, 500, 'SPIN', { font: '20px Arial', color: '#000' }).setOrigin(0.5);
+        const spinBtn = this.add.rectangle(700, 520, 120, 50, 0xff4444)
+            .setInteractive()
+            .setStrokeStyle(2, 0xffffff);
+        this.add.text(700, 520, 'GIRAR', { font: '24px Arial', color: '#fff' }).setOrigin(0.5);
         spinBtn.on('pointerdown', () => {
             this.manager.spin();
+        });
+
+        const maxBetBtn = this.add.rectangle(560, 520, 120, 50, 0x4444ff)
+            .setInteractive()
+            .setStrokeStyle(2, 0xffffff);
+        this.add.text(560, 520, 'APUESTA MAX', { font: '18px Arial', color: '#fff' }).setOrigin(0.5);
+        maxBetBtn.on('pointerdown', () => {
+            this.manager.setBetPerLine(5);
         });
     }
 }


### PR DESCRIPTION
## Summary
- add SVG fruit symbols and load them in BootScene
- display balance, win and bet with larger text
- draw background and frame in GameScene
- add buttons for spin and max bet
- document fruit theme in README

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684ced8c7b28833091fc999347fdedbb